### PR TITLE
Update signout for CSRF support

### DIFF
--- a/code/oauth/src/main/webapp/WEB-INF/crm/welcome.jsp
+++ b/code/oauth/src/main/webapp/WEB-INF/crm/welcome.jsp
@@ -14,7 +14,10 @@
 <sec:authorize ifAllGranted="ROLE_USER">
     <h1>Hi, <sec:authentication property="principal.username"/>!</h1>
 
-    <a href="${pageContext.request.contextPath}/signout">Sign Out</a>.
+    <form action="${pageContext.request.contextPath}/signout" method="post">
+        <input type="submit" value="Sign Out"/>
+        <input type="hidden" name="<c:out value="${_csrf.parameterName}"/>" value="<c:out value="${_csrf.token}"/>"/>
+    </form>
 </sec:authorize>
 
 <sec:authorize ifNotGranted="ROLE_USER">


### PR DESCRIPTION
Previously signout was performing a GET which is no longer valid with the
default JC support.

Now signout performs a POST and includes a CSRF token.
